### PR TITLE
[RFC] Proposal to make user protected in UserDTODataTransformer

### DIFF
--- a/src/BenGorUser/UserBundle/Security/UserSymfonyDataTransformer.php
+++ b/src/BenGorUser/UserBundle/Security/UserSymfonyDataTransformer.php
@@ -35,7 +35,7 @@ class UserSymfonyDataTransformer implements UserDataTransformer
      */
     public function write($aUser)
     {
-        if (!isset($aUser['email'], $aUser['encoded_password'], $aUser['roles'])) {
+        if (!isset($aUser['email'], $aUser['roles'])) {
             throw new \InvalidArgumentException(
                 'The user DTO must have at least keys of "email", "encoded_password" and "roles"'
             );


### PR DESCRIPTION
Even if leaving it private is safer could be interesting to change it to protected to allow developers reuse existing code.

This will make adding new properties to the domain and DTO easier, faster and less confusing
